### PR TITLE
Add null guard to NotificationUtils.getDescriptor()

### DIFF
--- a/bletia/src/main/java/info/izumin/android/bletia/util/NotificationUtils.java
+++ b/bletia/src/main/java/info/izumin/android/bletia/util/NotificationUtils.java
@@ -4,6 +4,7 @@ import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
 
 import java.util.Arrays;
+import java.util.UUID;
 
 import info.izumin.android.bletia.Bletia;
 
@@ -15,9 +16,16 @@ public final class NotificationUtils {
         throw new AssertionError("constructor of the utility class should not be called");
     }
 
+    public static UUID DESCRIPTOR_UUID = Bletia.CLIENT_CHARCTERISTIC_CONFIG;
+    public static int DESCRIPTOR_PERMISSION = BluetoothGattDescriptor.PERMISSION_WRITE;
+
     public static BluetoothGattDescriptor getDescriptor(BluetoothGattCharacteristic characteristic, boolean enabled) {
         byte[] value = enabled ? BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE : BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE;
         BluetoothGattDescriptor descriptor = characteristic.getDescriptor(Bletia.CLIENT_CHARCTERISTIC_CONFIG);
+        if (descriptor == null) {
+            descriptor = new BluetoothGattDescriptor(DESCRIPTOR_UUID, DESCRIPTOR_PERMISSION);
+            characteristic.addDescriptor(descriptor);
+        }
         descriptor.setValue(value);
         return descriptor;
     }


### PR DESCRIPTION
https://github.com/YUKAI/konashi-android-sdk/issues/1

When does not has the descriptor, instantiate it and add to the characteristic.
